### PR TITLE
Fix the unreliable method of finding the Picture-in-Picture video tab…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# PiP Media Seeker
+
+PiP Media Seeker is a Chrome extension that allows you to seek forward and backward in Picture-in-Picture (PiP) videos using keyboard shortcuts. This is especially useful for platforms that don't natively support seeking in their PiP players.
+
+## Features
+
+- **Seek forward and backward:** Use custom keyboard shortcuts to jump through your video content.
+- **Customizable seek duration:** Choose between 5, 10, 15, or 30-second seek intervals via the extension popup.
+- **Enable/Disable:** Easily toggle the extension on or off from the popup.
+
+## Installation
+
+1.  **Download:** Download this repository as a ZIP file and unzip it on your local machine.
+2.  **Open Chrome Extensions:** Open Google Chrome and navigate to `chrome://extensions`.
+3.  **Enable Developer Mode:** Turn on the "Developer mode" toggle in the top-right corner.
+4.  **Load Unpacked:** Click the "Load unpacked" button and select the unzipped extension folder.
+5.  The extension should now be installed and active.
+
+## How to Use
+
+The core functionality of this extension relies on keyboard shortcuts. You need to set them up manually.
+
+1.  **Open Keyboard Shortcuts:** Navigate to `chrome://extensions/shortcuts`.
+2.  **Find PiP Media Seeker:** Locate the "PiP Media Seeker" card.
+3.  **Set Shortcuts:** You will see two unassigned actions:
+    -   `Seeks forward in the PiP video.`
+    -   `Seeks backward in the PiP video.`
+4.  Click the pencil icon next to each action and press the key combination you wish to use (e.g., `Ctrl+Right Arrow` for forward and `Ctrl+Left Arrow` for backward).
+
+Once configured, you can use these shortcuts to seek in any active Picture-in-Picture video.
+
+## Configuration
+
+You can configure the extension by clicking on its icon in the Chrome toolbar. The popup allows you to:
+
+-   **Enable or Disable** the extension.
+-   Set the **seek duration** (5, 10, 15, or 30 seconds). The default is 10 seconds.

--- a/background.js
+++ b/background.js
@@ -9,13 +9,13 @@ async function handleSeek(direction) {
     return;
   }
 
-  const [pipWindow] = await chrome.tabs.query({
-    windowType: 'normal',
+  // Query for all audible tabs
+  const audibleTabs = await chrome.tabs.query({
     audible: true
   });
 
-  if (!pipWindow) {
-    return;
+  if (!audibleTabs || audibleTabs.length === 0) {
+    return; // No audible tabs found
   }
 
   const seekFunction = (direction, seconds) => {
@@ -26,14 +26,29 @@ async function handleSeek(direction) {
       } else if (direction === 'backward') {
         video.currentTime -= seconds;
       }
+      return true; // Indicate success
     }
+    return false; // Indicate failure
   };
 
-  await chrome.scripting.executeScript({
-    target: { tabId: pipWindow.id },
-    func: seekFunction,
-    args: [direction, seekSeconds]
-  });
+  // Iterate through all audible tabs and try to seek
+  for (const tab of audibleTabs) {
+    try {
+      const results = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: seekFunction,
+        args: [direction, seekSeconds],
+      });
+
+      // If the script returned true, we've found the PiP video and can stop.
+      if (results && results[0] && results[0].result) {
+        break;
+      }
+    } catch (e) {
+      // Ignore errors for tabs where script injection is not allowed (e.g., chrome:// pages)
+      // console.error(`Failed to inject script in tab ${tab.id}: ${e.message}`);
+    }
+  }
 }
 
 // Listen for the commands defined in manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,11 @@
   },
   "permissions": [
     "scripting",
-    "activeTab",
     "tabs",
     "storage"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "commands": {
     "seek_forward": {


### PR DESCRIPTION
…. The new implementation iterates through all audible tabs to find the one with an active PiP element.

The `manifest.json` is updated to include `<all_urls>` in `host_permissions` to support this change.

Additionally, a comprehensive `README.md` file is added to explain the extension's features, installation process, and how to configure the keyboard shortcuts.